### PR TITLE
(MAINT) Add Michael Lombardi 2019 talk info

### DIFF
--- a/2019/Readme.md
+++ b/2019/Readme.md
@@ -19,7 +19,7 @@
 | Sipping psake: Creating a Build and Release Pipeline for PowerShell                            | Brandon Olin               |           |
 | Demystifying Microsoft's Cloud Automation products                                             | Jaap Brasser               |           |
 | It’s PowerShell In the Cloud – Welcome to Azure Cloud Shell                                    | [Michael Bender](https://twitter.com/michaelbender)             |  [Scripts & Slides](https://github.com/themichaelbender-ms/azure-cloud-shell)         |
-| Doctor, Don't Defenestrate: What to Do with Legacy Scripts                                     | Michael T Lombardi         |           |
+| Doctor, Don't Defenestrate: What to Do with Legacy Scripts                                     | [Michael T Lombardi](https://twitter.com/barbariankb) | [Slides](https://gitpitch.com/michaeltlombardi/talks?p=doctor-dont-defenestrate#/), [Slides with notes](https://gitpitch.com/michaeltlombardi/talks?p=doctor-dont-defenestrate&n=true#/) |
 | Moving Up the Monitoring Stack                                                                 | Steven Murawski            |           |
 | PowerShell Remoting Internals                                                                  | Paul Higinbotham           |           |
 | Continuously deploying SQL code using Powershell                                               | Kirill Kravtsov            |           |
@@ -46,7 +46,7 @@
 | Containers - You Better Get on Board                                                           | Anthony Nocentino          |           |
 | Don't do that, do this instead: PowerShell worst practices and how to solve them               | [Chris Gardner](https://chrislgardner.github.io)              |  [slides](https://github.com/ChrisLGardner/presentations)      |
 | Better Ops Together: Practical PowerShell Pair Programming Patterns and Practices with VS Code | Mark Kraus                 |           |
-| Dungeons & Dragons & Development: How Playing Games Makes You a Better IT Pro                  | Michael T Lombardi         |           |
+| Dungeons & Dragons & Development: How Playing Games Makes You a Better IT Pro                  | [Michael T Lombardi](https://twitter.com/barbariankb) | [Slides](https://gitpitch.com/michaeltlombardi/talks?p=dndnd#/), [Slides with notes](https://gitpitch.com/michaeltlombardi/talks?p=dndnd&n=true#/) |
 | Demystifying Terraform - "Hardcore" to Core Infrastructure-as-Code Tool                        | [Chris Hunt](https://twitter.com/LogicalDiagram)                 | [Slides and Code](https://github.com/cdhunt/pssummit2019-terraform)          |
 | PesterSec: Using Pester & ScriptAnalyzer for Detecting Obfuscated PowerShell                   | Daniel Bohannon            |           |
 | PowerShell + AutoRest + Swagger = Instant Modules                                              | Adam Murray                |           |


### PR DESCRIPTION
This commit updates the 2019 talk readme with my twitter handle and links
to the slides for my talks.